### PR TITLE
Fix update binary issue

### DIFF
--- a/src/AzureBlobStorage/AzureBlobProvider.cs
+++ b/src/AzureBlobStorage/AzureBlobProvider.cs
@@ -82,11 +82,9 @@ namespace SenseNet.BlobStorage.Azure
         {
             SnTrace.Database.Write("AzureBlobProvider.Allocate: {0}", context.BlobProviderData);
 
-            var blobId = ((AzureBlobProviderData)context.BlobProviderData)?.BlobId;
-
             context.BlobProviderData = new AzureBlobProviderData
             {
-                BlobId = blobId ?? NewBlobId(),
+                BlobId = NewBlobId(),
                 ChunkSize = ChunkSize
             };
         }


### PR DESCRIPTION
When someone updates a binary it was getting stored in the previous binary's blob and the binary cleanup logic was deleting it making the binary disappear after a time.